### PR TITLE
Add some optimizations

### DIFF
--- a/mininec/mininec.py
+++ b/mininec/mininec.py
@@ -1113,7 +1113,7 @@ class Mininec:
                 if k == 1 or not self.media or self.media [0].is_ideal:
                     s2   = self.w * np.sum \
                         (pv.point * kvec * rvrp.real, axis = 2)
-                    s    = np.exp(1j * s2)
+                    s    = np.exp (1j * s2)
                     sshp = list (s.shape)
                     sshp.insert (-1, 2)
                     ss   = np.reshape (np.repeat (s, 2, axis = 0), sshp)
@@ -1431,7 +1431,7 @@ class Mininec:
             valid = np.logical_and (d, opt > 0)
             # We can use idx0 or idx 1 because we established both
             # pulses have same wire at that point
-            for wire in np.unique(idx0 [valid]):
+            for wire in np.unique (idx0 [valid]):
                 v = np.logical_and (valid, idx0 == wire)
                 a, b = np.where (v)
                 if len (a) < 2:
@@ -1899,7 +1899,7 @@ class Mininec:
             )
         b1 = d * self.w
         # EXP(-J*K*R)/R
-        t34 += np.exp(-1j * b1) / d
+        t34 += np.exp (-1j * b1) / d
         return t34
     #end def integral_i2_i3
 
@@ -2066,7 +2066,7 @@ class Mininec:
         # the upper integration bound and fast_quad needs a scalar)
         for quad in (8, 4, 2):
             qidx = np.logical_and (rest_idx, gauss_n == quad)
-            for f2val in np.unique(f2):
+            for f2val in np.unique (f2):
                 i = np.logical_and (qidx, f2 == f2val)
                 if i.any ():
                     if len (vecv.shape) == 1:

--- a/mininec/mininec.py
+++ b/mininec/mininec.py
@@ -1113,7 +1113,7 @@ class Mininec:
                 if k == 1 or not self.media or self.media [0].is_ideal:
                     s2   = self.w * np.sum \
                         (pv.point * kvec * rvrp.real, axis = 2)
-                    s    = np.e ** (1j * s2)
+                    s    = np.exp(1j * s2)
                     sshp = list (s.shape)
                     sshp.insert (-1, 2)
                     ss   = np.reshape (np.repeat (s, 2, axis = 0), sshp)
@@ -1431,7 +1431,7 @@ class Mininec:
             valid = np.logical_and (d, opt > 0)
             # We can use idx0 or idx 1 because we established both
             # pulses have same wire at that point
-            for wire in set (idx0 [valid]):
+            for wire in np.unique(idx0 [valid]):
                 v = np.logical_and (valid, idx0 == wire)
                 a, b = np.where (v)
                 if len (a) < 2:
@@ -1899,7 +1899,7 @@ class Mininec:
             )
         b1 = d * self.w
         # EXP(-J*K*R)/R
-        t34 += np.e ** (-1j * b1) / d
+        t34 += np.exp(-1j * b1) / d
         return t34
     #end def integral_i2_i3
 
@@ -1955,7 +1955,6 @@ class Mininec:
         55.7187703 -0.1465045j
         """
         if n in legendre_cache and a == 0:
-            
             x, w = legendre_cache [n]
             y = (x + .5) * b
             return np.sum (w * self.integral_i2_i3 (y, *args), axis = -1)
@@ -2067,7 +2066,7 @@ class Mininec:
         # the upper integration bound and fast_quad needs a scalar)
         for quad in (8, 4, 2):
             qidx = np.logical_and (rest_idx, gauss_n == quad)
-            for f2val in set (f2):
+            for f2val in np.unique(f2):
                 i = np.logical_and (qidx, f2 == f2val)
                 if i.any ():
                     if len (vecv.shape) == 1:
@@ -2852,11 +2851,11 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     WIRE NO.  1 :
     PULSE         REAL          IMAGINARY     MAGNITUDE     PHASE
      NO.          (AMPS)        (AMPS)        (AMPS)        (DEGREES)
-     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609  
-     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147 
-     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472  
-     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722  
-     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092 
+     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609
+     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147
+     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472
+     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722
+     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092
     E              0             0             0             0
     <BLANKLINE>
     ********************     FAR FIELD      ********************
@@ -2867,13 +2866,13 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     ********************    PATTERN DATA    ********************
     ZENITH        AZIMUTH       VERTICAL      HORIZONTAL    TOTAL
      ANGLE         ANGLE        PATTERN (DB)  PATTERN (DB)  PATTERN (DB)
-     0             0            -999          -999          -999     
+     0             0            -999          -999          -999
      45            0             1.163918     -999           1.163918
      90            0             5.119285     -999           5.119285
-     0             180          -999          -999          -999     
+     0             180          -999          -999          -999
      45            180           1.163918     -999           1.163918
      90            180           5.119285     -999           5.119285
-     0             360          -999          -999          -999     
+     0             360          -999          -999          -999
      45            360           1.163918     -999           1.163918
      90            360           5.119285     -999           5.119285
     <BLANKLINE>
@@ -2891,11 +2890,11 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     WIRE NO.  1 :
     PULSE         REAL          IMAGINARY     MAGNITUDE     PHASE
      NO.          (AMPS)        (AMPS)        (AMPS)        (DEGREES)
-     1             2.851291E-02  1.014723E-03  2.853096E-02  2.038193 
-     2             2.721271E-02  6.814274E-05  2.721279E-02  .143473  
-     3             2.341369E-02 -4.509546E-04  2.341803E-02 -1.103397 
-     4             1.740291E-02 -6.326805E-04  1.741441E-02 -2.082063 
-     5             9.581812E-03 -4.870737E-04  9.594184E-03 -2.91002  
+     1             2.851291E-02  1.014723E-03  2.853096E-02  2.038193
+     2             2.721271E-02  6.814274E-05  2.721279E-02  .143473
+     3             2.341369E-02 -4.509546E-04  2.341803E-02 -1.103397
+     4             1.740291E-02 -6.326805E-04  1.741441E-02 -2.082063
+     5             9.581812E-03 -4.870737E-04  9.594184E-03 -2.91002
     E              0             0             0             0
     <BLANKLINE>
     ********************     FAR FIELD      ********************
@@ -2906,14 +2905,14 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     ********************    PATTERN DATA    ********************
     ZENITH        AZIMUTH       VERTICAL      HORIZONTAL    TOTAL
      ANGLE         ANGLE        PATTERN (DB)  PATTERN (DB)  PATTERN (DB)
-     0             0            -999          -999          -999     
-     45            0             1.16192      -999           1.16192 
+     0             0            -999          -999          -999
+     45            0             1.16192      -999           1.16192
      90            0             5.120395     -999           5.120395
-     0             180          -999          -999          -999     
-     45            180           1.16192      -999           1.16192 
+     0             180          -999          -999          -999
+     45            180           1.16192      -999           1.16192
      90            180           5.120395     -999           5.120395
-     0             360          -999          -999          -999     
-     45            360           1.16192      -999           1.16192 
+     0             360          -999          -999          -999
+     45            360           1.16192      -999           1.16192
      90            360           5.120395     -999           5.120395
 
     >>> args = ['-f', '7.15', '-w', '5,0,0,0,0,0,10.0838,0.0127']
@@ -2966,11 +2965,11 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     WIRE NO.  1 :
     PULSE         REAL          IMAGINARY     MAGNITUDE     PHASE
      NO.          (AMPS)        (AMPS)        (AMPS)        (DEGREES)
-     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609  
-     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147 
-     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472  
-     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722  
-     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092 
+     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609
+     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147
+     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472
+     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722
+     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092
     E              0             0             0             0
     <BLANKLINE>
     ********************     FAR FIELD      ********************
@@ -3042,11 +3041,11 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     WIRE NO.  1 :
     PULSE         REAL          IMAGINARY     MAGNITUDE     PHASE
      NO.          (AMPS)        (AMPS)        (AMPS)        (DEGREES)
-     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609  
-     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147 
-     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472  
-     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722  
-     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092 
+     1             2.857798E-02  1.660853E-03  2.862620E-02  3.32609
+     2             2.727548E-02  6.861985E-04  2.728411E-02  1.441147
+     3             2.346944E-02  8.170773E-05  2.346959E-02  .199472
+     4             1.744657E-02 -2.362219E-04  1.744817E-02 -.775722
+     5             9.607629E-03 -2.685486E-04  9.611381E-03 -1.601092
     E              0             0             0             0
     <BLANKLINE>
     ********************    NEAR FIELDS     ********************
@@ -3058,7 +3057,7 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     NEW POWER LEVEL (WATTS) =  100
     <BLANKLINE>
     ********************NEAR ELECTRIC FIELDS********************
-             FIELD POINT: X =  1         Y =  1         Z =  1       
+             FIELD POINT: X =  1         Y =  1         Z =  1
       VECTOR      REAL          IMAGINARY     MAGNITUDE     PHASE
      COMPONENT     V/M           V/M           V/M           DEG
        X           4.129238     -10.56496      11.34324     -68.65233
@@ -3075,7 +3074,7 @@ def main (argv = sys.argv [1:], f_err = sys.stderr, return_mininec = False):
     NEW POWER LEVEL (WATTS) =  100
     <BLANKLINE>
     ********************NEAR MAGNETIC FIELDS********************
-             FIELD POINT: X =  1         Y =  1         Z =  1       
+             FIELD POINT: X =  1         Y =  1         Z =  1
       VECTOR      REAL          IMAGINARY     MAGNITUDE     PHASE
      COMPONENT     AMPS/M        AMPS/M        AMPS/M        DEG
        X          -.187091      -4.272377E-03  .187139      -178.6918

--- a/mininec/pulse.py
+++ b/mininec/pulse.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python3 
+#!/usr/bin/python3
 # Copyright (C) 2024 Ralf Schlatterbeck. All rights reserved
 # Reichergasse 131, A-3411 Weidling
 # ****************************************************************************
-#   
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -12,19 +12,26 @@
 #
 #   The above copyright notice and this permission notice shall be included in
 #   all copies or substantial portions of the Software.
-#   
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE. 
+# SOFTWARE.
 # ****************************************************************************
 
+import collections
+import itertools
 import numpy as np
 from functools import cached_property
 from mininec.util import format_float
+
+
+def wires_connected(w1, w2):
+    return w1.is_connected (w2) or w2.is_connected (w1)
+
 
 class Pulse_Container:
 
@@ -203,10 +210,25 @@ class Pulse_Container:
         if getattr (self, '_matrix_wires_unconnected', None) is None:
             l = len (self)
             r = np.zeros ((l, l), dtype = bool)
-            for p1 in self:
-                for p2 in self:
-                    if p1.wires_unconnected (p2):
-                        r [p1.idx, p2.idx] = True
+
+            # Collect all wires and wire -> pulses mapping
+            wires = []
+            wire_pulses_map = collections.defaultdict(list)
+            for p_id, p in enumerate(self):
+                if p.wire not in wires:
+                    wires.append(p.wire)
+                w_id = wires.index(p.wire)
+                wire_pulses_map[w_id].append(p_id)
+
+            # Check connectivity between each pair of wires and update unconnected
+            # matrix for pulses
+            for (w1_id, w1), (w2_id, w2) in itertools.combinations(enumerate(wires), 2):
+                if not wires_connected(w1, w2):
+                    ixgrig1 = np.ix_(wire_pulses_map[w1_id], wire_pulses_map[w2_id])
+                    ixgrig2 = np.ix_(wire_pulses_map[w2_id], wire_pulses_map[w1_id])
+                    r[ixgrig1] = True
+                    r[ixgrig2] = True
+
             self._matrix_wires_unconnected = r
         return self._matrix_wires_unconnected
     # end def matrix_wires_unconnected
@@ -312,7 +334,7 @@ class Pulse:
         w1 = self.wire
         w2 = other.wire
         # Well this should really be symmetric, so one should be enough :-)
-        return not w1.is_connected (w2) and not w2.is_connected (w1)
+        return not wires_connected(w1, w2)
     # end def wires_unconnected
 
 # end class Pulse

--- a/test/test_mininec.py
+++ b/test/test_mininec.py
@@ -8,10 +8,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 #   The above copyright notice and this permission notice shall be included in
-#   all copies or substantial portions of the Software. 
-# 
+#   all copies or substantial portions of the Software.
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -271,8 +271,7 @@ class _Test_Base_With_File:
         assert acc.endswith (' J)')
         exc = [float (x) for x in exc [11:-3].split (',')]
         acc = [float (x) for x in acc [11:-3].split (',')]
-        assert round (abs (exc [0] - acc [0]), 12) == 0
-        assert round (abs (exc [1] - acc [1]), 12) == 0
+        assert np.allclose(exc, acc)
         off += 1
         state = 0
         for l_ex, l_ac in zip (ex [off:], ac [off:]):

--- a/test/test_mininec.py
+++ b/test/test_mininec.py
@@ -271,7 +271,7 @@ class _Test_Base_With_File:
         assert acc.endswith (' J)')
         exc = [float (x) for x in exc [11:-3].split (',')]
         acc = [float (x) for x in acc [11:-3].split (',')]
-        assert np.allclose(exc, acc)
+        assert np.allclose (exc, acc, atol=1e-12)
         off += 1
         state = 0
         for l_ex, l_ac in zip (ex [off:], ac [off:]):


### PR DESCRIPTION
* Replace `np.e ** <smth>` with `np.exp(<smth>)`.
* Replace `set(np.ndarray)` with `np.unique(np.ndarray)`.
* Update computing `matrix_wires_unconnected`.

Firs 2 changes are faster, because it uses numpy optimization and skips converting numpy objects to pure python (np.int64 -> int). Last change check connectivity between ech pair of wires, instead of each pair of pulse and significant reduces computation time.